### PR TITLE
Added Clone trait to data structures

### DIFF
--- a/src/kdtree.rs
+++ b/src/kdtree.rs
@@ -90,7 +90,7 @@ where
 }
 
 /// Internal structure used to store items in the k‑nearest neighbor heap.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct HeapItem<P> {
     dist: OrderedFloat<f64>,
     point: P,
@@ -117,7 +117,7 @@ impl<P> Ord for HeapItem<P> {
 }
 
 /// A node in the Kd‑tree containing a point and references to its children.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 struct KdNode<P: KdPoint> {
     point: P,
@@ -140,7 +140,7 @@ impl<P: KdPoint> KdNode<P> {
 ///
 /// The tree stores points in k‑dimensional space (where `k` is provided during creation)
 /// and supports insertion, k‑nearest neighbor search, range search, and deletion.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct KdTree<P: KdPoint> {
     root: Option<Box<KdNode<P>>>,

--- a/src/octree.rs
+++ b/src/octree.rs
@@ -43,7 +43,7 @@ use tracing::info;
 /// # Panics
 ///
 /// Panics with `SpartError::InvalidCapacity` if `capacity` is zero.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Octree<T: Clone + PartialEq> {
     boundary: Cube,

--- a/src/quadtree.rs
+++ b/src/quadtree.rs
@@ -44,7 +44,7 @@ use tracing::{debug, info};
 /// # Panics
 ///
 /// Panics with `SpartError::InvalidCapacity` if `capacity` is zero.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Quadtree<T: Clone + PartialEq> {
     boundary: Rectangle,

--- a/src/rstar_tree.rs
+++ b/src/rstar_tree.rs
@@ -108,7 +108,7 @@ pub struct RStarTreeNode<T: RStarTreeObject> {
 ///
 /// The tree is initialized with a maximum number of entries per node. If a node exceeds this
 /// number, it will split. The tree supports insertion, deletion, and range searches.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RStarTree<T: RStarTreeObject> {
     root: RStarTreeNode<T>,

--- a/src/rtree.rs
+++ b/src/rtree.rs
@@ -102,7 +102,7 @@ pub struct RTreeNode<T: RTreeObject> {
 ///
 /// The tree is initialized with a maximum number of entries per node. If a node exceeds this
 /// number, it will split. The tree supports insertion, deletion, and range searches.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RTree<T: RTreeObject> {
     root: RTreeNode<T>,


### PR DESCRIPTION
Very tiny pull request. 
All I've done is adding a #[derive(Clone)] to KdTree, Octree, Quadtree, RStarTree, RTree because a trait bound in one of my projects demands it.